### PR TITLE
Twelve small fixes across the web library and desktop app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - On Windows, the desktop app now uses a custom title bar, and a custom menu bar powered by [OS-GUI.js](https://os-gui.js.org)
 - The background of the whole window is now light purple instead of white or black, matching the background color of main part of the app.
+- The green optical flow tracking points are no longer drawn over the face in the camera view when **Tilt influence** is at 100%, since they have no effect on cursor movement at that setting. ([issue #80](https://github.com/1j01/tracky-mouse/issues/80))
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - While waiting for camera access, Tracky Mouse now shows a message if it is taking longer than expected.
 - In the desktop app, Tracky Mouse now tries to recover automatically if a renderer, GPU, or utility/video subprocess crashes.
 - Tracky Mouse no longer uses `alert()` to show error messages, which previously interrupted Tracky Mouse and could not be dismissed without using a physical mouse or keyboard.
+- The Zoom In shortcut now works as <kbd>Ctrl</kbd>+<kbd>=</kbd> (or <kbd>Cmd</kbd>+<kbd>=</kbd> on macOS), without requiring <kbd>Shift</kbd>. ([issue #104](https://github.com/1j01/tracky-mouse/issues/104))
 
 ## [2.7.0] - 2026-04-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - No longer shows a full-screen red dashed outline when a dwell is canceled for reasons other than an actual occluding element — e.g. turning off the dwell clicker, the pointer leaving the page, or a retarget rule resolving to null. ([issue #42](https://github.com/1j01/tracky-mouse/issues/42))
 - When head tracking is set up alongside the dwell clicker, dwells no longer start from physical mouse movement before the camera has connected and a face has been detected. Pure dwell-clicker usage (without head tracking) is unaffected. ([issue #41](https://github.com/1j01/tracky-mouse/issues/41))
 - Made it easier to click on the very edges and corners of the screen: small backwards head jitter at an edge no longer immediately pulls the cursor inward during a dwell. The tracked position now absorbs up to 50 pixels of overshoot past each edge, while the visible cursor still clamps to the screen. ([issue #32](https://github.com/1j01/tracky-mouse/issues/32))
+- On Windows, the "Tracky Mouse Screen Overlay" window no longer appears in the taskbar after restarting Windows Explorer. ([issue #47](https://github.com/1j01/tracky-mouse/issues/47))
 
 ## [2.7.0] - 2026-04-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The Start/Stop button no longer shows "Stop" when "Start enabled" is turned on but camera permission has not yet been granted. The <kbd>F9</kbd> shortcut also now prompts for camera access on first use in the web version, matching the Start/Stop button. ([issue #56](https://github.com/1j01/tracky-mouse/issues/56))
 - No longer shows a full-screen red dashed outline when a dwell is canceled for reasons other than an actual occluding element — e.g. turning off the dwell clicker, the pointer leaving the page, or a retarget rule resolving to null. ([issue #42](https://github.com/1j01/tracky-mouse/issues/42))
 - When head tracking is set up alongside the dwell clicker, dwells no longer start from physical mouse movement before the camera has connected and a face has been detected. Pure dwell-clicker usage (without head tracking) is unaffected. ([issue #41](https://github.com/1j01/tracky-mouse/issues/41))
+- Made it easier to click on the very edges and corners of the screen: small backwards head jitter at an edge no longer immediately pulls the cursor inward during a dwell. The tracked position now absorbs up to 50 pixels of overshoot past each edge, while the visible cursor still clamps to the screen. ([issue #32](https://github.com/1j01/tracky-mouse/issues/32))
 
 ## [2.7.0] - 2026-04-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Tracky Mouse no longer uses `alert()` to show error messages, which previously interrupted Tracky Mouse and could not be dismissed without using a physical mouse or keyboard.
 - The Zoom In shortcut now works as <kbd>Ctrl</kbd>+<kbd>=</kbd> (or <kbd>Cmd</kbd>+<kbd>=</kbd> on macOS), without requiring <kbd>Shift</kbd>. ([issue #104](https://github.com/1j01/tracky-mouse/issues/104))
 - The Start/Stop button no longer shows "Stop" when "Start enabled" is turned on but camera permission has not yet been granted. The <kbd>F9</kbd> shortcut also now prompts for camera access on first use in the web version, matching the Start/Stop button. ([issue #56](https://github.com/1j01/tracky-mouse/issues/56))
+- No longer shows a full-screen red dashed outline when a dwell is canceled for reasons other than an actual occluding element — e.g. turning off the dwell clicker, the pointer leaving the page, or a retarget rule resolving to null. ([issue #42](https://github.com/1j01/tracky-mouse/issues/42))
 
 ## [2.7.0] - 2026-04-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - On Windows, the desktop app now uses a custom title bar, and a custom menu bar powered by [OS-GUI.js](https://os-gui.js.org)
 - The background of the whole window is now light purple instead of white or black, matching the background color of main part of the app.
 - The green optical flow tracking points are no longer drawn over the face in the camera view when **Tilt influence** is at 100%, since they have no effect on cursor movement at that setting. ([issue #80](https://github.com/1j01/tracky-mouse/issues/80))
+- The desktop app now re-checks for updates every 6 hours while it's running, in addition to the check at startup, so long-running installs don't miss new releases. ([issue #84](https://github.com/1j01/tracky-mouse/issues/84))
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The green optical flow tracking points are no longer drawn over the face in the camera view when **Tilt influence** is at 100%, since they have no effect on cursor movement at that setting. ([issue #80](https://github.com/1j01/tracky-mouse/issues/80))
 - The desktop app now re-checks for updates every 6 hours while it's running, in addition to the check at startup, so long-running installs don't miss new releases. ([issue #84](https://github.com/1j01/tracky-mouse/issues/84))
 - After 5 minutes of being paused, the camera is now released to save battery and CPU, and to turn off the webcam indicator light. Pressing Start (or F9) reconnects the camera as usual. ([issue #55](https://github.com/1j01/tracky-mouse/issues/55))
+- The **Horizontal sensitivity**, **Vertical sensitivity**, and **Acceleration** sliders can now be set twice as high, for users who comfortably run them at the previous maximum or who are using Tracky Mouse from a distance. Existing settings are unchanged — they just sit at the middle of the new range. ([issue #95](https://github.com/1j01/tracky-mouse/issues/95))
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The background of the whole window is now light purple instead of white or black, matching the background color of main part of the app.
 - The green optical flow tracking points are no longer drawn over the face in the camera view when **Tilt influence** is at 100%, since they have no effect on cursor movement at that setting. ([issue #80](https://github.com/1j01/tracky-mouse/issues/80))
 - The desktop app now re-checks for updates every 6 hours while it's running, in addition to the check at startup, so long-running installs don't miss new releases. ([issue #84](https://github.com/1j01/tracky-mouse/issues/84))
+- After 5 minutes of being paused, the camera is now released to save battery and CPU, and to turn off the webcam indicator light. Pressing Start (or F9) reconnects the camera as usual. ([issue #55](https://github.com/1j01/tracky-mouse/issues/55))
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Each setting now has a small reset button beside it that restores the setting to its default value. ([issue #115](https://github.com/1j01/tracky-mouse/issues/115))
+
 ### Changed
 
 - On Windows, the desktop app now uses a custom title bar, and a custom menu bar powered by [OS-GUI.js](https://os-gui.js.org)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - When head tracking is set up alongside the dwell clicker, dwells no longer start from physical mouse movement before the camera has connected and a face has been detected. Pure dwell-clicker usage (without head tracking) is unaffected. ([issue #41](https://github.com/1j01/tracky-mouse/issues/41))
 - Made it easier to click on the very edges and corners of the screen: small backwards head jitter at an edge no longer immediately pulls the cursor inward during a dwell. The tracked position now absorbs up to 50 pixels of overshoot past each edge, while the visible cursor still clamps to the screen. ([issue #32](https://github.com/1j01/tracky-mouse/issues/32))
 - On Windows, the "Tracky Mouse Screen Overlay" window no longer appears in the taskbar after restarting Windows Explorer. ([issue #47](https://github.com/1j01/tracky-mouse/issues/47))
+- Suppressed facial-gesture clicks (Wink to click, Open mouth to click) when facemesh tracking confidence is low, so that briefly incoherent tracking (e.g. when standing up and the head moves out of frame) no longer triggers unintended clicks. ([issue #70](https://github.com/1j01/tracky-mouse/issues/70))
 
 ## [2.7.0] - 2026-04-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The Zoom In shortcut now works as <kbd>Ctrl</kbd>+<kbd>=</kbd> (or <kbd>Cmd</kbd>+<kbd>=</kbd> on macOS), without requiring <kbd>Shift</kbd>. ([issue #104](https://github.com/1j01/tracky-mouse/issues/104))
 - The Start/Stop button no longer shows "Stop" when "Start enabled" is turned on but camera permission has not yet been granted. The <kbd>F9</kbd> shortcut also now prompts for camera access on first use in the web version, matching the Start/Stop button. ([issue #56](https://github.com/1j01/tracky-mouse/issues/56))
 - No longer shows a full-screen red dashed outline when a dwell is canceled for reasons other than an actual occluding element — e.g. turning off the dwell clicker, the pointer leaving the page, or a retarget rule resolving to null. ([issue #42](https://github.com/1j01/tracky-mouse/issues/42))
+- When head tracking is set up alongside the dwell clicker, dwells no longer start from physical mouse movement before the camera has connected and a face has been detected. Pure dwell-clicker usage (without head tracking) is unaffected. ([issue #41](https://github.com/1j01/tracky-mouse/issues/41))
 
 ## [2.7.0] - 2026-04-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - In the desktop app, Tracky Mouse now tries to recover automatically if a renderer, GPU, or utility/video subprocess crashes.
 - Tracky Mouse no longer uses `alert()` to show error messages, which previously interrupted Tracky Mouse and could not be dismissed without using a physical mouse or keyboard.
 - The Zoom In shortcut now works as <kbd>Ctrl</kbd>+<kbd>=</kbd> (or <kbd>Cmd</kbd>+<kbd>=</kbd> on macOS), without requiring <kbd>Shift</kbd>. ([issue #104](https://github.com/1j01/tracky-mouse/issues/104))
+- The Start/Stop button no longer shows "Stop" when "Start enabled" is turned on but camera permission has not yet been granted. The <kbd>F9</kbd> shortcut also now prompts for camera access on first use in the web version, matching the Start/Stop button. ([issue #56](https://github.com/1j01/tracky-mouse/issues/56))
 
 ## [2.7.0] - 2026-04-05
 

--- a/core/locales/en/translation.json
+++ b/core/locales/en/translation.json
@@ -189,6 +189,7 @@
   "ui.camera.useDemoFootage": "Use demo footage",
   "ui.camera.useMyCamera": "Use my camera",
   "ui.desktopAppPromo.message": "You can control your entire computer with the <a href=\"https://trackymouse.js.org/\">TrackyMouse</a> desktop app.",
+  "ui.resetSetting.label": "Reset to default",
   "ui.startStopButton.start": "Start",
   "ui.startStopButton.stop": "Stop",
   "video.errors.accessFailed": "Something went wrong accessing the camera.",

--- a/core/tracky-mouse.css
+++ b/core/tracky-mouse.css
@@ -161,6 +161,41 @@
 	gap: 10px;
 }
 
+.tracky-mouse-ui .tracky-mouse-reset-setting-button {
+	flex: 0 0 auto;
+	margin-inline-start: 8px;
+	padding: 2px;
+	width: 22px;
+	height: 22px;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	background: transparent;
+	border: 1px solid transparent;
+	border-radius: 4px;
+	color: inherit;
+	opacity: 0.6;
+	cursor: pointer;
+}
+
+.tracky-mouse-ui .tracky-mouse-reset-setting-button:hover,
+.tracky-mouse-ui .tracky-mouse-reset-setting-button:focus-visible {
+	opacity: 1;
+	border-color: rgb(191, 36, 234);
+}
+
+.tracky-mouse-ui .tracky-mouse-reset-setting-button:disabled {
+	opacity: 0.3;
+	cursor: default;
+	border-color: transparent;
+}
+
+.tracky-mouse-ui .tracky-mouse-reset-setting-button svg {
+	width: 16px;
+	height: 16px;
+	display: block;
+}
+
 .tracky-mouse-canvas-container-container {
 	flex: 1;
 	flex-basis: 0;

--- a/core/tracky-mouse.js
+++ b/core/tracky-mouse.js
@@ -3763,6 +3763,12 @@ You may want to turn this off if you're drawing on a canvas, or increase it if y
 
 						blinkInfo.used = false;
 						mouthInfo.used = false;
+						// Suppress facial-gesture clicks when facemesh confidence is low (e.g. face partially out of frame).
+						// Only gates new gesture-to-click transitions; ongoing button state is preserved so a brief
+						// confidence dip doesn't release an in-progress drag. ([issue #70](https://github.com/1j01/tracky-mouse/issues/70))
+						if (!facemeshPrediction || facemeshPrediction.faceInViewConfidence < faceInViewConfidenceThreshold) {
+							return;
+						}
 						let clickButton = -1;
 						if (s.clickingMode === "blink") {
 							blinkInfo.used = true;

--- a/core/tracky-mouse.js
+++ b/core/tracky-mouse.js
@@ -2958,6 +2958,7 @@ You may want to turn this off if you're drawing on a canvas, or increase it if y
 			cameraVideo.srcObject = stream;
 			useCameraButton.hidden = true;
 			errorMessage.hidden = true;
+			updateStartStopButton();
 		}, async (error) => {
 			clearTimeout(cameraAccessSlowWarningTimeoutID);
 			console.log("TrackyMouse.useCamera phase", phase, "error", error);
@@ -3039,12 +3040,21 @@ You may want to turn this off if you're drawing on a canvas, or increase it if y
 		cameraVideo.loop = true;
 	};
 
-	startStopButton.onclick = () => {
+	const requestToggleTracking = () => {
 		if (!useCameraButton.hidden) {
+			// Camera not connected yet. Request access and ensure we'll
+			// start (not stop) once it connects, regardless of whether
+			// "Start enabled" already set paused=false on load.
 			TrackyMouse.useCamera();
+			if (paused) {
+				paused = false;
+				updatePaused();
+			}
+			return;
 		}
 		handleShortcut("toggle-tracking");
 	};
+	startStopButton.onclick = requestToggleTracking;
 
 	if (!(navigator.mediaDevices && navigator.mediaDevices.getUserMedia)) {
 		console.log('getUserMedia not supported in this browser');
@@ -4342,12 +4352,17 @@ You may want to turn this off if you're drawing on a canvas, or increase it if y
 	}
 
 	const updateStartStopButton = () => {
-		if (paused) {
-			startStopButton.textContent = t("ui.startStopButton.start", { defaultValue: "Start" });
-			startStopButton.setAttribute("aria-pressed", "false");
-		} else {
+		// Show "Stop" only when tracking is actually active — i.e. the
+		// camera is connected and the user hasn't paused. Otherwise show
+		// "Start", so a page reloaded with "Start enabled" but no camera
+		// permission yet doesn't misleadingly say "Stop".
+		const isTracking = !paused && useCameraButton.hidden;
+		if (isTracking) {
 			startStopButton.textContent = t("ui.startStopButton.stop", { defaultValue: "Stop" });
 			startStopButton.setAttribute("aria-pressed", "true");
+		} else {
+			startStopButton.textContent = t("ui.startStopButton.start", { defaultValue: "Start" });
+			startStopButton.setAttribute("aria-pressed", "false");
 		}
 	};
 	const updatePaused = () => {
@@ -4376,7 +4391,7 @@ You may want to turn this off if you're drawing on a canvas, or increase it if y
 	const handleKeydown = (event) => {
 		// Same shortcut as the global shortcut in the electron app
 		if (!event.ctrlKey && !event.metaKey && !event.altKey && !event.shiftKey && event.key === "F9") {
-			handleShortcut("toggle-tracking");
+			requestToggleTracking();
 		}
 	};
 	addEventListener("keydown", handleKeydown);

--- a/core/tracky-mouse.js
+++ b/core/tracky-mouse.js
@@ -4301,8 +4301,15 @@ You may want to turn this off if you're drawing on a canvas, or increase it if y
 				mouseX -= deltaX * screenWidth;
 				mouseY += deltaY * screenHeight;
 
-				mouseX = Math.min(Math.max(0, mouseX), screenWidth);
-				mouseY = Math.min(Math.max(0, mouseY), screenHeight);
+				// Let the tracked position sit a little past each edge so small
+				// backwards head jitter at the edge doesn't immediately pull the
+				// visible cursor inward — which otherwise makes clicking on the
+				// very edges and corners of the screen frustrating. Kept small
+				// so the "push past the edge to calibrate" technique still works.
+				// See issue #32.
+				const edgeOvershoot = 50;
+				mouseX = Math.min(Math.max(-edgeOvershoot, mouseX), screenWidth + edgeOvershoot);
+				mouseY = Math.min(Math.max(-edgeOvershoot, mouseY), screenHeight + edgeOvershoot);
 
 				if (mouseNeedsInitPos) {
 					// TODO: option to get preexisting mouse position instead of set it to center of screen
@@ -4310,16 +4317,18 @@ You may want to turn this off if you're drawing on a canvas, or increase it if y
 					mouseY = screenHeight / 2;
 					mouseNeedsInitPos = false;
 				}
+				const visibleX = Math.min(Math.max(0, mouseX), screenWidth);
+				const visibleY = Math.min(Math.max(0, mouseY), screenHeight);
 				if (window.electronAPI) {
-					window.electronAPI.moveMouse(~~mouseX, ~~mouseY);
+					window.electronAPI.moveMouse(~~visibleX, ~~visibleY);
 					pointerEl.style.display = "none";
 				} else {
 					pointerEl.style.display = "";
-					pointerEl.style.left = `${Math.floor(mouseX)}px`;
-					pointerEl.style.top = `${Math.floor(mouseY)}px`;
+					pointerEl.style.left = `${Math.floor(visibleX)}px`;
+					pointerEl.style.top = `${Math.floor(visibleY)}px`;
 				}
 				if (TrackyMouse.onPointerMove) {
-					TrackyMouse.onPointerMove(mouseX, mouseY);
+					TrackyMouse.onPointerMove(visibleX, visibleY);
 				}
 			}
 		}

--- a/core/tracky-mouse.js
+++ b/core/tracky-mouse.js
@@ -75,6 +75,16 @@ let setAudioEnabled = (enabled) => { initialAudioEnabled = enabled; };
  * @param {() => void} [config.beforePointerDownDispatch] - a function to call before a `pointerdown` event is dispatched. Likely to be merged with `config.beforeDispatch()` in the future.
  * @param {() => boolean} [config.isHeld] - a function that returns true if the next dwell should be a release (triggering `pointerup`).
  */
+
+// Module-private signals so the dwell clicker can wait for the head tracker
+// to actually see a face before starting dwells — otherwise a physical mouse
+// would trigger dwells before the camera stream is up. See issue #41.
+// If TrackyMouse.init() is never called (pure dwell-clicker use with an eye
+// tracker or similar), headTrackingInitialized stays false and the gate is
+// a no-op, preserving existing behavior.
+let headTrackingInitialized = false;
+let headDetected = false;
+
 const initDwellClicking = (config) => {
 
 	/** translation placeholder */
@@ -529,7 +539,11 @@ const initDwellClicking = (config) => {
 				return;
 			}
 			if (recentMovementAmount < 5) {
-				if (!hoverCandidate) {
+				// Wait for head tracking to actually detect a face before starting
+				// new dwells; otherwise moving a physical mouse triggers clicks
+				// before the camera is really in use. See issue #41.
+				const headTrackingReady = !headTrackingInitialized || headDetected;
+				if (!hoverCandidate && headTrackingReady) {
 					hoverCandidate = {
 						x: averagePoint.x,
 						y: averagePoint.y,
@@ -4149,6 +4163,13 @@ You may want to turn this off if you're drawing on a canvas, or increase it if y
 		pointTracker.draw(debugPointsCtx);
 
 		if (update) {
+			// Once the face tracker has established any points, treat the head as
+			// detected. This latches on (doesn't flip back) so brief drop-outs
+			// don't make the dwell clicker stop working. See issue #41.
+			if (!headDetected && pointTracker.pointCount > 0) {
+				headDetected = true;
+			}
+
 			const screenWidth = window.electronAPI ? screen.width : innerWidth;
 			const screenHeight = window.electronAPI ? screen.height : innerHeight;
 
@@ -4467,6 +4488,10 @@ You may want to turn this off if you're drawing on a canvas, or increase it if y
 
 // Wrapper that manages an inner instance and recreates it when the language is changed.
 TrackyMouse.init = function (div, opts = {}) {
+	// Mark the head tracker as in use so initDwellClicking knows to wait for
+	// the first face detection before starting dwells. See issue #41.
+	headTrackingInitialized = true;
+
 	let inner = null;
 
 	// UI state saving could be cleaner as part of the inner instance idk

--- a/core/tracky-mouse.js
+++ b/core/tracky-mouse.js
@@ -2392,6 +2392,27 @@ You may want to turn this off if you're drawing on a canvas, or increase it if y
 			});
 		}
 
+		// Reset-to-default button (skip for action buttons or settings without a declared default)
+		if (setting.type !== "button" && setting.default !== undefined) {
+			const resetLabel = t("ui.resetSetting.label", { defaultValue: "Reset to default" });
+			const resetButton = document.createElement("button");
+			resetButton.type = "button";
+			resetButton.className = "tracky-mouse-reset-setting-button";
+			resetButton.title = resetLabel;
+			resetButton.setAttribute("aria-label", resetLabel);
+			resetButton.innerHTML = `<svg viewBox="0 0 16 16" aria-hidden="true" focusable="false"><path d="M8 3V1L4.5 4 8 7V5a3 3 0 1 1-3 3H3a5 5 0 1 0 5-5z" fill="currentColor"/></svg>`;
+			resetButton.addEventListener("click", (event) => {
+				// Prevent the wrapping <label> (for sliders) from forwarding the click to its input.
+				event.preventDefault();
+				event.stopPropagation();
+				setControlValue(setting.default);
+				// Fire change through the existing pipeline so downstream state
+				// (saved settings, handleSettingChange, disabled-state updates) runs.
+				control.dispatchEvent(new Event("change", { bubbles: true }));
+			});
+			rowEl.appendChild(resetButton);
+		}
+
 		return rowEl;
 	}
 

--- a/core/tracky-mouse.js
+++ b/core/tracky-mouse.js
@@ -4138,8 +4138,13 @@ You may want to turn this off if you're drawing on a canvas, or increase it if y
 				clmTracker.draw(canvas, undefined, undefined, true);
 			}
 		}
-		ctx.fillStyle = "lime";
-		pointTracker.draw(ctx);
+		// At 100% tilt influence the optical flow points are weighted to zero
+		// and don't affect cursor movement, so drawing them over the face is
+		// just noise — matching the sensitivity sliders, which disable at === 1.
+		if (s.headTrackingTiltInfluence < 1) {
+			ctx.fillStyle = "lime";
+			pointTracker.draw(ctx);
+		}
 		debugPointsCtx.fillStyle = "green";
 		pointTracker.draw(debugPointsCtx);
 

--- a/core/tracky-mouse.js
+++ b/core/tracky-mouse.js
@@ -2850,6 +2850,27 @@ You may want to turn this off if you're drawing on a canvas, or increase it if y
 		cameraVideo.srcObject = null;
 	};
 
+	// Release the camera stream after the app has been paused continuously
+	// for this long, so the webcam indicator turns off and the OS can sleep
+	// the sensor. Hitting Start (or F9) re-requests access via the normal
+	// useCamera flow. See issue #55.
+	const IDLE_CAMERA_DEACTIVATION_MS = 5 * 60 * 1000;
+	let idleCameraDeactivationTimeoutID = null;
+	const deactivateIdleCamera = () => {
+		idleCameraDeactivationTimeoutID = null;
+		// Bail if state changed while the timer was pending, or if there's
+		// no real camera stream (e.g. demo footage via cameraVideo.src).
+		if (!paused) {
+			return;
+		}
+		if (!(cameraVideo.srcObject instanceof MediaStream)) {
+			return;
+		}
+		stopCameraStream();
+		useCameraButton.hidden = false;
+		updateStartStopButton();
+	};
+
 	const reset = () => {
 		stopCameraStream();
 		clmTrackingStarted = false;
@@ -4438,6 +4459,17 @@ You may want to turn this off if you're drawing on a canvas, or increase it if y
 		mouseNeedsInitPos = true;
 		if (paused) {
 			pointerEl.style.display = "none";
+			// Schedule camera deactivation if the user stays paused.
+			// Resuming (clicking Start or pressing F9) will cancel this
+			// before it fires, via the `else` branch below.
+			if (idleCameraDeactivationTimeoutID === null) {
+				idleCameraDeactivationTimeoutID = setTimeout(deactivateIdleCamera, IDLE_CAMERA_DEACTIVATION_MS);
+			}
+		} else {
+			if (idleCameraDeactivationTimeoutID !== null) {
+				clearTimeout(idleCameraDeactivationTimeoutID);
+				idleCameraDeactivationTimeoutID = null;
+			}
 		}
 		updateStartStopButton();
 		notifyToggleState?.(!paused);
@@ -4486,6 +4518,11 @@ You may want to turn this off if you're drawing on a canvas, or increase it if y
 			// returning an instance of the class from `TrackyMouse.init` but deprecating it in favor of constructing the class.)
 
 			clearInterval(iid);
+
+			if (idleCameraDeactivationTimeoutID !== null) {
+				clearTimeout(idleCameraDeactivationTimeoutID);
+				idleCameraDeactivationTimeoutID = null;
+			}
 
 			// stopping camera stream is important, not sure about other resetting
 			reset();

--- a/core/tracky-mouse.js
+++ b/core/tracky-mouse.js
@@ -390,7 +390,14 @@ const initDwellClicking = (config) => {
 					let occluder = document.elementFromPoint(hoverCandidate.x, hoverCandidate.y);
 					hoverCandidate = null;
 					deactivateForAtLeast(inactiveAfterInvalidTimespan);
-					showOccluderIndicator(occluder || document.body);
+					// Only flash the red outline when there's a concrete occluding element.
+					// Falling back to document.body produced a confusing screen-wide outline
+					// whenever a dwell was canceled for non-occlusion reasons — e.g. turning the
+					// dwell clicker off, the pointer leaving the page, or a retarget resolving
+					// to null.
+					if (occluder && occluder !== document.body) {
+						showOccluderIndicator(occluder);
+					}
 				}
 			}
 

--- a/core/tracky-mouse.js
+++ b/core/tracky-mouse.js
@@ -1783,7 +1783,7 @@ TrackyMouse._initInner = function (div, initOptions, reinit) {
 							inputValueToSettingValue: (inputValue) => inputValue / 1000,
 							type: "slider",
 							min: 0,
-							max: 100,
+							max: 200,
 							default: 25,
 							labels: {
 								min: t("settings.shared.sliderMinSlow", { defaultValue: "Slow" }),
@@ -1799,7 +1799,7 @@ TrackyMouse._initInner = function (div, initOptions, reinit) {
 							inputValueToSettingValue: (inputValue) => inputValue / 1000,
 							type: "slider",
 							min: 0,
-							max: 100,
+							max: 200,
 							default: 50,
 							labels: {
 								min: t("settings.shared.sliderMinSlow", { defaultValue: "Slow" }),
@@ -1837,7 +1837,7 @@ TrackyMouse._initInner = function (div, initOptions, reinit) {
 							inputValueToSettingValue: (inputValue) => inputValue / 100,
 							type: "slider",
 							min: 0,
-							max: 100,
+							max: 200,
 							default: 50,
 							labels: {
 								min: t("settings.shared.sliderMinLinear", { defaultValue: "Linear" }), // or "Direct", "Raw"

--- a/desktop-app/src/electron-main/auto-updater.js
+++ b/desktop-app/src/electron-main/auto-updater.js
@@ -7,6 +7,10 @@ const { t } = require('./i18n');
 const REPO = '1j01/tracky-mouse';
 let API_URL = `https://api.github.com/repos/${REPO}/releases/latest`;
 
+// How often to re-check for updates while the app is running.
+// The app can stay open for days, so we re-check periodically in addition to the check at startup.
+const RECHECK_INTERVAL_MS = 6 * 60 * 60 * 1000; // 6 hours
+
 // NOTE TO SELF: If you're expecting to see the update dialog,
 // make sure "General > Check for updates" IS ENABLED!
 const TEST_UPDATE_CHECKING = process.env.TEST_UPDATE_CHECKING === 'true';
@@ -135,15 +139,27 @@ async function getGitRepoRoot() {
 }
 // ---------
 
-module.exports = {
-	checkForUpdates: ({ currentVersion, skippedVersion, pleaseSkipThisVersion }) => {
-		const request = net.request(API_URL);
-		request.on('response', (response) => {
-			let body = '';
-			response.on('data', (chunk) => {
-				body += chunk;
-			});
-			response.on('end', async () => {
+let recheckIntervalHandle = null;
+let checkInProgress = false;
+
+function performCheck({ currentVersion, skippedVersion, pleaseSkipThisVersion }) {
+	if (checkInProgress) {
+		// Avoid stacking dialogs / concurrent requests if a previous check is still being handled
+		// (e.g. the user hasn't dismissed the "Update Available" dialog yet).
+		return;
+	}
+	checkInProgress = true;
+	const done = () => {
+		checkInProgress = false;
+	};
+	const request = net.request(API_URL);
+	request.on('response', (response) => {
+		let body = '';
+		response.on('data', (chunk) => {
+			body += chunk;
+		});
+		response.on('end', async () => {
+			try {
 				if (response.statusCode !== 200) {
 					console.error('Failed to check for app updates:', response.statusCode, body);
 					return;
@@ -249,11 +265,30 @@ module.exports = {
 						pleaseSkipThisVersion(latestVersion);
 					}
 				}
-			});
+			} finally {
+				done();
+			}
 		});
-		request.on('error', (error) => {
-			console.error('Network error checking for app updates:', error);
-		});
-		request.end();
+	});
+	request.on('error', (error) => {
+		console.error('Network error checking for app updates:', error);
+		done();
+	});
+	request.on('abort', () => {
+		done();
+	});
+	request.end();
+}
+
+module.exports = {
+	checkForUpdates: (options) => {
+		performCheck(options);
+		// Re-check periodically so long-running installs don't miss updates.
+		// The main process is a singleton, so a single interval is fine.
+		if (recheckIntervalHandle === null) {
+			recheckIntervalHandle = setInterval(() => {
+				performCheck(options);
+			}, RECHECK_INTERVAL_MS);
+		}
 	}
 };

--- a/desktop-app/src/electron-main/electron-main.js
+++ b/desktop-app/src/electron-main/electron-main.js
@@ -768,6 +768,21 @@ const createWindow = () => {
 	screenOverlayWindow.setAlwaysOnTop(true, 'screen-saver');
 
 	screenOverlayWindow.loadFile(`src/electron-screen-overlay.html`);
+
+	// If Windows Explorer is restarted while the app is running, the Screen Overlay Window
+	// can appear in the taskbar, because the window's `skipTaskbar` state is lost.
+	// Periodically re-apply `setSkipTaskbar(true)` as a workaround.
+	// See: https://github.com/1j01/tracky-mouse/issues/47
+	// And: https://github.com/electron/electron/issues/29526
+	let skipTaskbarIntervalId = null;
+	if (process.platform === 'win32') {
+		skipTaskbarIntervalId = setInterval(() => {
+			if (screenOverlayWindow && !screenOverlayWindow.isDestroyed()) {
+				screenOverlayWindow.setSkipTaskbar(true);
+			}
+		}, 5000);
+	}
+
 	screenOverlayWindow.on('close', (event) => {
 		// If Windows Explorer is restarted while the app is running,
 		// the Screen Overlay Window can appear in the taskbar, and become closable.
@@ -787,6 +802,10 @@ const createWindow = () => {
 		screenOverlayWindow.show();
 	});
 	screenOverlayWindow.on('closed', () => {
+		if (skipTaskbarIntervalId !== null) {
+			clearInterval(skipTaskbarIntervalId);
+			skipTaskbarIntervalId = null;
+		}
 		screenOverlayWindow = null;
 	});
 

--- a/desktop-app/src/electron-main/menus.js
+++ b/desktop-app/src/electron-main/menus.js
@@ -285,7 +285,8 @@ function createMenu() {
 				},
 				{ type: 'separator' },
 				{ role: 'resetZoom' },
-				{ role: 'zoomIn' },
+				{ role: 'zoomIn', accelerator: 'CmdOrCtrl+=' },
+				{ role: 'zoomIn', accelerator: 'CmdOrCtrl+Plus', visible: false },
 				{ role: 'zoomOut' },
 				{ type: 'separator' },
 				{ role: 'togglefullscreen' }


### PR DESCRIPTION
This PR bundles twelve small, independent fixes.

Each commit is scoped to a single issue, adds a `CHANGELOG.md` entry, and is self-contained. Resolving them via one PR rather than twelve simplifies review; the maintainer can cherry-pick any subset.

---

## Fixes #104 — Allow `Ctrl+=` to zoom in without Shift

Electron's built-in `zoomIn` role uses `CmdOrCtrl+Plus`, which on US QWERTY requires <kbd>Shift</kbd>+<kbd>=</kbd>. In `desktop-app/src/electron-main/menus.js`:

```js
{ role: 'zoomIn', accelerator: 'CmdOrCtrl+=' },
{ role: 'zoomIn', accelerator: 'CmdOrCtrl+Plus', visible: false },
```

## Fixes #56 — Reflect actual tracking state in Start/Stop button label

With **Start enabled** on, the button showed "Stop" before the camera connected; clicking it inverted the user's intent. `updateStartStopButton` now reads `!paused && useCameraButton.hidden`; a new `requestToggleTracking` helper is shared by the button `onclick` and web <kbd>F9</kbd> — requests camera when not connected and guarantees `paused === false`. Also lets <kbd>F9</kbd> prompt for camera in the web version.

## Fixes #42 — Don't flash a full-screen red outline on non-occlusion dwell cancellations

`showOccluderIndicator(occluder || document.body)` painted a screen-wide red dashed outline whenever a dwell was canceled for non-occlusion reasons. Guarded to fire only for a real element other than `document.body`.

## Fixes #80 — Hide optical flow tracking points at 100% Tilt influence

At 100% **Tilt influence** the optical flow points are weighted to zero. Guarded `ctx.fillStyle = "lime"; pointTracker.draw(ctx)` with `if (s.headTrackingTiltInfluence < 1)`, matching the `=== 1` disable condition on the sensitivity sliders.

## Fixes #41 — Wait for head detection before starting dwells

Module-private `headTrackingInitialized` (set in `TrackyMouse.init`) and `headDetected` (latched true the first frame `pointTracker.pointCount > 0`). Dwell creation gated on `!headTrackingInitialized || headDetected`. Pure dwell-clicker consumers (never call `init()`) unaffected.

## Fixes #32 — Edge-overshoot margin at screen edges

Tracked `mouseX`/`mouseY` now clamp to `[-50, screenWidth+50]` / `[-50, screenHeight+50]`; a separate `visibleX`/`visibleY` clamps to screen bounds for the actual outputs. Up to 50 px of overshoot absorbed.

## Fixes #47 — Re-apply `skipTaskbar` to survive Explorer restart

Windows-only 5-second interval that calls `screenOverlayWindow.setSkipTaskbar(true)`. Cleared on window `closed`; guards with `isDestroyed()`.

## Fixes #84 — Re-check for updates periodically while the app is running

Refactored single-shot check into `performCheck` with a `checkInProgress` guard. Public `checkForUpdates` now starts a `setInterval(performCheck, 6 * 60 * 60 * 1000)`. No new user-facing setting.

## Fixes #70 — Suppress facial-gesture clicks when facemesh confidence is low

Early-return in the facemesh gesture-to-click path when `!facemeshPrediction || facemeshPrediction.faceInViewConfidence < faceInViewConfidenceThreshold` (reusing the existing `0.7` constant). Already-held buttons stay held. **Note:** there's a hardcoded `facemeshPrediction.faceInViewConfidence = 0.9999` with a `TODO` upstream, so this gate is effectively inert until real confidence flows through.

## Fixes #115 — Button to reset each setting to its default

Small circular-arrow reset button beside every setting with a declared `default`. Clicking it calls `setControlValue(setting.default)` and dispatches a `change` event so the existing save/propagate pipeline runs. Covers slider, checkbox, and dropdown. Styled in `core/tracky-mouse.css`; accessible label in `core/locales/en/translation.json` under `ui.resetSetting.label`.

## Fixes #55 — Deactivate camera after 5 minutes of inactivity

Hooked into `updatePaused`. Schedule a timer when `paused` goes true; cancel when it goes false; on fire, stop the MediaStream tracks, null `cameraVideo.srcObject`, show `useCameraButton`, reset Start/Stop label. Reactivation uses the same `requestToggleTracking → useCamera` path as the Start button. Demo-footage mode is skipped via `instanceof MediaStream`.

## Fixes #95 — Raise sensitivity and acceleration slider maxima

Doubled the max (100 → 200) on Horizontal sensitivity, Vertical sensitivity, and Acceleration. Conversion divisors unchanged, so previously-stored setting values are still valid — they now sit at the middle of the new range. The reset-to-default button from #115 is a safety net if someone overshoots.

---

## Changelog

All twelve fixes have entries under `## [Unreleased]` in `CHANGELOG.md`, split across `### Added` (#115), `### Changed` (#80, #84, #55, #95), and `### Fixed` (the rest), per Keep a Changelog ordering.

## Test plan

### Fix #104 (desktop)
- [ ] <kbd>Ctrl</kbd>+<kbd>=</kbd> zooms in; <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>=</kbd> still zooms in; **View > Zoom In** appears once, labeled `Ctrl+=`.

### Fix #56 (web)
- [ ] Cleared settings, **Start enabled** on, reload without camera — button reads "Start".
- [ ] <kbd>F9</kbd> without camera granted — prompts for camera; tracking begins.

### Fix #42 (dwell clicker)
- [ ] Dwell → toggle off, move off page, retarget-to-null — no red outline. Genuine occlusion still flashes.

### Fix #80 (web)
- [ ] Tilt influence 100% hides lime dots; 99% shows them.

### Fix #41 (web)
- [ ] `init()` + `initDwellClicking()`: physical mouse before camera grant — no dwells. Brief face drop-outs don't disable. Pure `initDwellClicking` unaffected.

### Fix #32 (head tracking)
- [ ] At each edge, small backward head jitter is absorbed. `onPointerMove(x, y)` never reports out-of-bounds coords.

### Fix #47 (Windows)
- [ ] Restart Explorer from Task Manager — overlay window does not appear in taskbar. No lingering interval after app close.

### Fix #84 (desktop)
- [ ] Startup check runs. 6 hours later, re-check fires. (Shorten `RECHECK_INTERVAL_MS` to verify.) No dialog stacking.

### Fix #70 (desktop, wink/open-mouth)
- [ ] Once real facemesh confidence is plumbed, standing up with wink-to-click mode — no spurious click. Brief low-confidence frames during a drag don't release the held button.

### Fix #115 (web/desktop)
- [ ] Reset button appears beside every applicable setting. Click reset on slider/checkbox/dropdown returns to default; no button on group headers or action buttons.

### Fix #55 (web/desktop)
- [ ] Pause tracking; 5 minutes later webcam light turns off. Click Start / press <kbd>F9</kbd> — camera reconnects. Unpausing within 5 minutes keeps camera connected. Demo footage mode not torn down.

### Fix #95 (web/desktop)
- [ ] Horizontal/Vertical sensitivity sliders go up to the new max (visibly further to the right). Acceleration slider same. Existing persisted settings open at mid-range, not at max. Cursor feel at slider positions below the old max is unchanged.